### PR TITLE
Add epoch to cassandra RPM version for tools dependency

### DIFF
--- a/redhat/cassandra.spec
+++ b/redhat/cassandra.spec
@@ -158,7 +158,7 @@ exit 0
 %package tools
 Summary:       Extra tools for Cassandra. Cassandra is a highly scalable, eventually consistent, distributed, structured key-value store.
 Group:         Development/Libraries
-Requires:      cassandra = %{version}-%{revision}
+Requires:      cassandra = %{epoch}:%{version}-%{revision}
 
 %description tools
 Cassandra is a distributed (peer-to-peer) system for the management and storage of structured data.


### PR DESCRIPTION
The `cassandra-tools` package depends on the exact same version of
`cassandra`. Add the epoch introduced in 804a2301 to the `Requires`
field of `cassandra.spec` to fullfil this dependency with the
`cassandra` package built from the same sources.