### PR TITLE
new option to ignore incoming connection encryption if set

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -240,6 +240,7 @@ public class Config
     public EncryptionOptions.ServerEncryptionOptions encryption_options;
     public Boolean listen_on_storage_port;
     public Boolean listen_on_ssl_storage_port;
+    public Boolean external_addressing_mode;
 
     public InternodeCompression internode_compression = InternodeCompression.none;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2119,6 +2119,12 @@ public class DatabaseDescriptor
         }
     }
 
+    public static boolean isExternalAddressingMode() {
+        if (conf.external_addressing_mode == null)
+            return false;
+        return conf.external_addressing_mode;
+    }
+
     public static boolean shouldListenOnSslStoragePort() {
         if (conf.listen_on_ssl_storage_port == null)
             return getServerEncryptionOptions().internode_encryption != EncryptionOptions.ServerEncryptionOptions.InternodeEncryption.none;

--- a/src/java/org/apache/cassandra/net/IncomingStreamingConnection.java
+++ b/src/java/org/apache/cassandra/net/IncomingStreamingConnection.java
@@ -72,7 +72,9 @@ public class IncomingStreamingConnection extends Thread implements Closeable
             {
                 logger.warn("Peer {} attempted to establish an unencrypted streaming connection (broadcast address {})",
                             socket.getRemoteSocketAddress(), init.from);
-                throw new IOException("Peer " + init.from + " attempted an unencrypted streaming connection");
+                if (DatabaseDescriptor.isExternalAddressingMode()) {
+                    throw new IOException("Peer " + init.from + " attempted an unencrypted streaming connection");
+                }
             }
 
             //Set SO_TIMEOUT on follower side

--- a/src/java/org/apache/cassandra/net/IncomingTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/IncomingTcpConnection.java
@@ -160,7 +160,9 @@ public class IncomingTcpConnection extends FastThreadLocalThread implements Clos
         {
             logger.warn("Peer {} attempted to establish an unencrypted connection (broadcast address {})",
                         socket.getRemoteSocketAddress(), from);
-            throw new IOException("Peer " + from + " attempted an unencrypted connection");
+            if (DatabaseDescriptor.isExternalAddressingMode()) {
+                throw new IOException("Peer " + from + " attempted an unencrypted streaming connection");
+            }
         }
 
         // record the (true) version of the endpoint


### PR DESCRIPTION
c2f24d2c45aae6030310d881dcd96ba60d04a2ad
The commit disallows unencrypted connection when the node expects
encrypted connection.

In simpler words, As soon as node is configured with encryption(nodeA) it
wont accept unencrypted connection (nodeB. nodeC). And inserts with
consistency 2 in a 3 node(nodeA, nodeB, nodeC) cluster would stop
working a soon as (nodeB) goes down, even though 2 nodes (nodeA [expects
encryption], and nodeC [encryption-not-configured]) are up.

That commit includes test and inside those tests is a comment to further
clarify the situation:


    /*
    * instance (1) won't connect to (2), since (2) won't have a TLS listener;
    * instance (2) won't connect to (1), since inbound check will reject
    * the unencrypted connection attempt;
    *
    * without the patch, instance (2) *CAN* connect to (1), without encryption,
    * despite being in a different dc.
    */

Here instance1 is configured to have encryption (across DC's) and
instance(2) not at all. They belong to diffierent DC's

The patch add a new option. This options when set allows control over
enforcing the above decision (to terminate NON-SSL connection when SSL
is configured). If the option is set to true the check is enforced and
do not otherwise (also enforce if the option is not set, keeping the
behaviour backward compatible)