### PR TITLE
Make redhat packaging major-version dependent

### DIFF
--- a/redhat/cassandra.spec
+++ b/redhat/cassandra.spec
@@ -10,7 +10,7 @@
 
 %define relname apache-cassandra-%{version}
 
-Name:          cassandra
+Name:          cassandra3
 Epoch:         %{epoch}
 Version:       %{version}
 Release:       %{revision}
@@ -158,7 +158,7 @@ exit 0
 %package tools
 Summary:       Extra tools for Cassandra. Cassandra is a highly scalable, eventually consistent, distributed, structured key-value store.
 Group:         Development/Libraries
-Requires:      cassandra = %{epoch}:%{version}-%{revision}
+Requires:      cassandra3 = %{epoch}:%{version}-%{revision}
 
 %description tools
 Cassandra is a distributed (peer-to-peer) system for the management and storage of structured data.

--- a/redhat/cassandra.spec
+++ b/redhat/cassandra.spec
@@ -9,8 +9,10 @@
 %global username cassandra
 
 %define relname apache-cassandra-%{version}
+%define cassandra_major_version 3
+%define cassandraX cassandra%{cassandra_major_version}
 
-Name:          cassandra3
+Name:          %{cassandraX}
 Epoch:         %{epoch}
 Version:       %{version}
 Release:       %{revision}
@@ -52,18 +54,18 @@ ant clean jar -Dversion=%{version}
 
 %install
 %{__rm} -rf %{buildroot}
-mkdir -p %{buildroot}/%{_sysconfdir}/%{username}
-mkdir -p %{buildroot}/usr/share/%{username}
-mkdir -p %{buildroot}/usr/share/%{username}/lib
-mkdir -p %{buildroot}/%{_sysconfdir}/%{username}/default.conf
-mkdir -p %{buildroot}/usr/sbin
-mkdir -p %{buildroot}/usr/bin
-mkdir -p %{buildroot}/var/lib/%{username}/commitlog
-mkdir -p %{buildroot}/var/lib/%{username}/data
-mkdir -p %{buildroot}/var/lib/%{username}/saved_caches
-mkdir -p %{buildroot}/var/lib/%{username}/hints
-mkdir -p %{buildroot}/var/run/%{username}
-mkdir -p %{buildroot}/var/log/%{username}
+mkdir -p %{buildroot}/%{_sysconfdir}/%{cassandraX}
+mkdir -p %{buildroot}/usr/share/%{cassandraX}
+mkdir -p %{buildroot}/usr/share/%{cassandraX}/lib
+mkdir -p %{buildroot}/%{_sysconfdir}/%{cassandraX}/default.conf
+mkdir -p %{buildroot}/usr/%{cassandraX}/sbin
+mkdir -p %{buildroot}/usr/%{cassandraX}/bin
+mkdir -p %{buildroot}/var/lib/%{cassandraX}/commitlog
+mkdir -p %{buildroot}/var/lib/%{cassandraX}/data
+mkdir -p %{buildroot}/var/lib/%{cassandraX}/saved_caches
+mkdir -p %{buildroot}/var/lib/%{cassandraX}/hints
+mkdir -p %{buildroot}/var/run/%{cassandraX}
+mkdir -p %{buildroot}/var/log/%{cassandraX}
 ( cd pylib && python2.7 setup.py install --no-compile --root %{buildroot}; )
 
 # patches for data and log paths
@@ -83,25 +85,25 @@ rm -f tools/bin/*.bat
 rm -f tools/bin/cassandra.in.sh
 
 # copy default configs
-cp -pr conf/* %{buildroot}/%{_sysconfdir}/%{username}/default.conf/
+cp -pr conf/* %{buildroot}/%{_sysconfdir}/%{cassandraX}/default.conf/
 
 # step on default config with our redhat one
-cp -p redhat/%{username}.in.sh %{buildroot}/usr/share/%{username}/%{username}.in.sh
+cp -p redhat/%{username}.in.sh %{buildroot}/usr/share/%{cassandraX}/%{username}.in.sh
 
 # copy cassandra bundled libs
-cp -pr lib/* %{buildroot}/usr/share/%{username}/lib/
+cp -pr lib/* %{buildroot}/usr/share/%{cassandraX}/lib/
 
 # copy stress jar
-cp -p build/tools/lib/stress.jar %{buildroot}/usr/share/%{username}/
+cp -p build/tools/lib/stress.jar %{buildroot}/usr/share/%{cassandraX}/
 
 # copy binaries
-mv bin/cassandra %{buildroot}/usr/sbin/
-cp -p bin/* %{buildroot}/usr/bin/
-cp -p tools/bin/* %{buildroot}/usr/bin/
+mv bin/cassandra %{buildroot}/usr/%{cassandraX}/sbin/
+cp -p bin/* %{buildroot}/usr/%{cassandraX}/bin/
+cp -p tools/bin/* %{buildroot}/usr/%{cassandraX}/bin/
 
 # copy cassandra, thrift jars
-cp build/apache-cassandra-%{version}.jar %{buildroot}/usr/share/%{username}/
-cp build/apache-cassandra-thrift-%{version}.jar %{buildroot}/usr/share/%{username}/
+cp build/apache-cassandra-%{version}.jar %{buildroot}/usr/share/%{cassandraX}/
+cp build/apache-cassandra-thrift-%{version}.jar %{buildroot}/usr/share/%{cassandraX}/
 
 %clean
 %{__rm} -rf %{buildroot}
@@ -115,42 +117,30 @@ exit 0
 %files
 %defattr(0644,root,root,0755)
 %doc CHANGES.txt LICENSE.txt README.asc NEWS.txt NOTICE.txt CASSANDRA-14092.txt
-%attr(755,root,root) %{_bindir}/cassandra-stress
-%attr(755,root,root) %{_bindir}/cqlsh
-%attr(755,root,root) %{_bindir}/cqlsh.py
-%attr(755,root,root) %{_bindir}/debug-cql
-%attr(755,root,root) %{_bindir}/nodetool
-%attr(755,root,root) %{_bindir}/sstableloader
-%attr(755,root,root) %{_bindir}/sstablescrub
-%attr(755,root,root) %{_bindir}/sstableupgrade
-%attr(755,root,root) %{_bindir}/sstableutil
-%attr(755,root,root) %{_bindir}/sstableverify
-%attr(755,root,root) %{_bindir}/stop-server
-%attr(755,root,root) %{_sbindir}/cassandra
-/usr/share/%{username}*
-%config(noreplace) /%{_sysconfdir}/%{username}
-%attr(755,%{username},%{username}) %config(noreplace) /var/lib/%{username}/*
-%attr(755,%{username},%{username}) /var/log/%{username}*
-%attr(755,%{username},%{username}) /var/run/%{username}*
+%attr(755,root,root) /usr/%{cassandraX}/bin/cassandra-stress
+%attr(755,root,root) /usr/%{cassandraX}/bin/cqlsh
+%attr(755,root,root) /usr/%{cassandraX}/bin/cqlsh.py
+%attr(755,root,root) /usr/%{cassandraX}/bin/debug-cql
+%attr(755,root,root) /usr/%{cassandraX}/bin/nodetool
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstableloader
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstablescrub
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstableupgrade
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstableutil
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstableverify
+%attr(755,root,root) /usr/%{cassandraX}/bin/stop-server
+%attr(755,root,root) /usr/%{cassandraX}/sbin/cassandra
+/usr/share/%{cassandraX}*
+%config(noreplace) /%{_sysconfdir}/%{cassandraX}
+%attr(755,%{username},%{username}) %config(noreplace) /var/lib/%{cassandraX}/*
+%attr(755,%{username},%{username}) /var/log/%{cassandraX}*
+%attr(755,%{username},%{username}) /var/run/%{cassandraX}*
 /usr/lib/python2.7/site-packages/cqlshlib/
 /usr/lib/python2.7/site-packages/cassandra_pylib*.egg-info
-
-%post
-alternatives --install /%{_sysconfdir}/%{username}/conf %{username} /%{_sysconfdir}/%{username}/default.conf/ 0
-exit 0
-
-%preun
-# only delete alternative on removal, not upgrade
-if [ "$1" = "0" ]; then
-    alternatives --remove %{username} /%{_sysconfdir}/%{username}/default.conf/
-fi
-exit 0
-
 
 %package tools
 Summary:       Extra tools for Cassandra. Cassandra is a highly scalable, eventually consistent, distributed, structured key-value store.
 Group:         Development/Libraries
-Requires:      cassandra3 = %{epoch}:%{version}-%{revision}
+Requires:      %{cassandraX} = %{epoch}:%{version}-%{revision}
 Conflicts:     cassandra-tools
 
 %description tools
@@ -159,15 +149,15 @@ Cassandra is a distributed (peer-to-peer) system for the management and storage 
 This package contains extra tools for working with Cassandra clusters.
 
 %files tools
-%attr(755,root,root) %{_bindir}/sstabledump
-%attr(755,root,root) %{_bindir}/cassandra-stressd
-%attr(755,root,root) %{_bindir}/compaction-stress
-%attr(755,root,root) %{_bindir}/sstableexpiredblockers
-%attr(755,root,root) %{_bindir}/sstablelevelreset
-%attr(755,root,root) %{_bindir}/sstablemetadata
-%attr(755,root,root) %{_bindir}/sstableofflinerelevel
-%attr(755,root,root) %{_bindir}/sstablerepairedset
-%attr(755,root,root) %{_bindir}/sstablesplit
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstabledump
+%attr(755,root,root) /usr/%{cassandraX}/bin/cassandra-stressd
+%attr(755,root,root) /usr/%{cassandraX}/bin/compaction-stress
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstableexpiredblockers
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstablelevelreset
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstablemetadata
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstableofflinerelevel
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstablerepairedset
+%attr(755,root,root) /usr/%{cassandraX}/bin/sstablesplit
 
 
 %changelog

--- a/redhat/cassandra.spec
+++ b/redhat/cassandra.spec
@@ -30,6 +30,7 @@ Requires:      python(abi) >= 2.7
 Requires(pre): user(cassandra)
 Requires(pre): group(cassandra)
 Requires(pre): shadow-utils
+Conflicts:     cassandra
 Provides:      user(cassandra)
 Provides:      group(cassandra)
 
@@ -159,6 +160,7 @@ exit 0
 Summary:       Extra tools for Cassandra. Cassandra is a highly scalable, eventually consistent, distributed, structured key-value store.
 Group:         Development/Libraries
 Requires:      cassandra3 = %{epoch}:%{version}-%{revision}
+Conflicts:     cassandra-tools
 
 %description tools
 Cassandra is a distributed (peer-to-peer) system for the management and storage of structured data.

--- a/redhat/cassandra.spec
+++ b/redhat/cassandra.spec
@@ -56,9 +56,6 @@ mkdir -p %{buildroot}/%{_sysconfdir}/%{username}
 mkdir -p %{buildroot}/usr/share/%{username}
 mkdir -p %{buildroot}/usr/share/%{username}/lib
 mkdir -p %{buildroot}/%{_sysconfdir}/%{username}/default.conf
-mkdir -p %{buildroot}/%{_sysconfdir}/rc.d/init.d
-mkdir -p %{buildroot}/%{_sysconfdir}/security/limits.d
-mkdir -p %{buildroot}/%{_sysconfdir}/default
 mkdir -p %{buildroot}/usr/sbin
 mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/var/lib/%{username}/commitlog
@@ -90,9 +87,6 @@ cp -pr conf/* %{buildroot}/%{_sysconfdir}/%{username}/default.conf/
 
 # step on default config with our redhat one
 cp -p redhat/%{username}.in.sh %{buildroot}/usr/share/%{username}/%{username}.in.sh
-cp -p redhat/%{username} %{buildroot}/%{_sysconfdir}/rc.d/init.d/%{username}
-cp -p redhat/%{username}.conf %{buildroot}/%{_sysconfdir}/security/limits.d/
-cp -p redhat/default %{buildroot}/%{_sysconfdir}/default/%{username}
 
 # copy cassandra bundled libs
 cp -pr lib/* %{buildroot}/usr/share/%{username}/lib/
@@ -133,9 +127,6 @@ exit 0
 %attr(755,root,root) %{_bindir}/sstableverify
 %attr(755,root,root) %{_bindir}/stop-server
 %attr(755,root,root) %{_sbindir}/cassandra
-%attr(755,root,root) /%{_sysconfdir}/rc.d/init.d/%{username}
-%{_sysconfdir}/default/%{username}
-%{_sysconfdir}/security/limits.d/%{username}.conf
 /usr/share/%{username}*
 %config(noreplace) /%{_sysconfdir}/%{username}
 %attr(755,%{username},%{username}) %config(noreplace) /var/lib/%{username}/*


### PR DESCRIPTION
To be able to install cassandra3 and cassandra4 side-by-side and choose the necessary version dynamically.