### PR TITLE
Configure encryption on streaming connection if necessary

### DIFF
--- a/src/java/org/apache/cassandra/tools/BulkLoadConnectionFactory.java
+++ b/src/java/org/apache/cassandra/tools/BulkLoadConnectionFactory.java
@@ -47,7 +47,7 @@ public class BulkLoadConnectionFactory extends DefaultConnectionFactory implemen
         // does not know which node is in which dc/rack, connecting to SSL port is always the option.
 
         if (encryptionOptions != null && encryptionOptions.internode_encryption != EncryptionOptions.ServerEncryptionOptions.InternodeEncryption.none)
-            template = template.withConnectTo(template.to.withPort(secureStoragePort));
+            template = template.withConnectTo(template.to.withPort(secureStoragePort)).withEncryption(encryptionOptions);
 
         return super.createConnection(template, messagingVersion);
     }


### PR DESCRIPTION
Without this change `sstableloader` sends streaming traffic as plaintext, whereupon Cassandra server drops the connection with "wrong TLS version" error.