### PR TITLE
Apply Aiven-specific changes on top of upstream 4.1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+name: Build cassandra
+
+# Default to read-only access to all APIs.
+permissions: read-all
+
+on:
+  push: {}
+  pull_request: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+      - name: checkout-code
+        uses: actions/checkout@v3
+      - name: setup jdk 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: test
+        continue-on-error: true
+        run: |
+          ant test
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: "build/test/output/*.xml"

--- a/build.xml
+++ b/build.xml
@@ -523,7 +523,7 @@
         <license name="The Apache Software License, Version 2.0" url="https://www.apache.org/licenses/LICENSE-2.0.txt"/>
         <scm connection="${scm.connection}" developerConnection="${scm.developerConnection}" url="${scm.url}"/>
         <dependencyManagement>
-          <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.10.1"/>
+          <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.10.4"/>
           <dependency groupId="org.lz4" artifactId="lz4-java" version="1.8.0"/>
           <dependency groupId="com.ning" artifactId="compress-lzf" version="0.8.4" scope="provided"/>
           <dependency groupId="com.github.luben" artifactId="zstd-jni" version="1.5.5-1"/>

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -124,6 +124,7 @@ public class Config
     public Integer allocate_tokens_for_local_replication_factor = null;
 
     public boolean skip_bootstrap_streaming = false;
+    public String replace_address_first_boot = null;
 
     @Replaces(oldName = "native_transport_idle_timeout_in_ms", converter = Converters.MILLIS_DURATION_LONG, deprecated = true)
     public DurationSpec.LongMillisecondsBound native_transport_idle_timeout = new DurationSpec.LongMillisecondsBound("0ms");

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -123,6 +123,8 @@ public class Config
     /** Triggers automatic allocation of tokens if set, based on the provided replica count for a datacenter */
     public Integer allocate_tokens_for_local_replication_factor = null;
 
+    public boolean skip_bootstrap_streaming = false;
+
     @Replaces(oldName = "native_transport_idle_timeout_in_ms", converter = Converters.MILLIS_DURATION_LONG, deprecated = true)
     public DurationSpec.LongMillisecondsBound native_transport_idle_timeout = new DurationSpec.LongMillisecondsBound("0ms");
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1740,6 +1740,11 @@ public class DatabaseDescriptor
         }
     }
 
+    public static boolean skipBootstrapStreaming()
+    {
+        return conf.skip_bootstrap_streaming;
+    }
+
     public static Collection<String> getReplaceTokens()
     {
         return tokensFromString(System.getProperty(Config.PROPERTY_PREFIX + "replace_token", null));

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1732,6 +1732,8 @@ public class DatabaseDescriptor
                 return InetAddressAndPort.getByName(System.getProperty(Config.PROPERTY_PREFIX + "replace_address", null));
             else if (System.getProperty(Config.PROPERTY_PREFIX + "replace_address_first_boot", null) != null)
                 return InetAddressAndPort.getByName(System.getProperty(Config.PROPERTY_PREFIX + "replace_address_first_boot", null));
+            else if (conf.replace_address_first_boot != null)
+                return InetAddressAndPort.getByName(conf.replace_address_first_boot);
             return null;
         }
         catch (UnknownHostException e)
@@ -1743,6 +1745,11 @@ public class DatabaseDescriptor
     public static boolean skipBootstrapStreaming()
     {
         return conf.skip_bootstrap_streaming;
+    }
+
+    public static boolean replaceOnFirstBootRequested()
+    {
+        return System.getProperty("cassandra.replace_address_first_boot", null) != null || conf.replace_address_first_boot != null;
     }
 
     public static Collection<String> getReplaceTokens()

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2034,6 +2034,13 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         invalidateLocalRanges();
         repairPaxosForTopologyChange("bootstrap");
 
+        if (DatabaseDescriptor.skipBootstrapStreaming())
+        {
+            bootstrapFinished();
+            logger.info("Bootstrap skipped for tokens {}", tokens);
+            return true;
+        }
+
         Future<StreamState> bootstrapStream = startBootstrap(tokens);
         try
         {

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -994,7 +994,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (replacing)
             return true;
 
-        if (System.getProperty("cassandra.replace_address_first_boot", null) != null && SystemKeyspace.bootstrapComplete())
+        if (DatabaseDescriptor.replaceOnFirstBootRequested() && SystemKeyspace.bootstrapComplete())
         {
             logger.info("Replace address on first boot requested; this node is already bootstrapped");
             return false;

--- a/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
@@ -118,8 +118,12 @@ public class StartupMessage extends Message.Request
             clientState.setDriverVersion(options.get(DRIVER_VERSION));
         }
 
-        if (DatabaseDescriptor.getAuthenticator().requireAuthentication())
-            return new AuthenticateMessage(DatabaseDescriptor.getAuthenticator().getClass().getName());
+        if (DatabaseDescriptor.getAuthenticator().requireAuthentication()) {
+            String authenticatorClassName = DatabaseDescriptor.getAuthenticator().getClass().getName();
+            if (authenticatorClassName.equals("io.aiven.cassandra.auth.AivenAuthenticator"))
+                authenticatorClassName = "org.apache.cassandra.auth.PasswordAuthenticator";
+            return new AuthenticateMessage(authenticatorClassName);
+        }
         else
             return new ReadyMessage();
     }


### PR DESCRIPTION
- changes related to .spec file were omitted, we do not need them anymore
- RF uptuning functionality were omitted, because now we have guardrails framework for that
